### PR TITLE
Feature/elixir username support

### DIFF
--- a/dev-server/oidc/Dockerfile
+++ b/dev-server/oidc/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-slim
+FROM node:16.2.0-slim
 
 WORKDIR /app
 

--- a/dev-server/oidc/server.js
+++ b/dev-server/oidc/server.js
@@ -3,7 +3,8 @@ const camelCase = require('camelcase');
 const Provider = require('oidc-provider');
 
 const port = process.env.PORT || 3000;
-const ext_port = process.env.EXTERNAL_PORT || process.env.PORT;
+// External port can legally be an empty string
+const ext_port = process.env.EXTERNAL_PORT ?? process.env.PORT;
 const host = process.env.HOST || "oidc" ;
 
 const config = ['CLIENT_ID', 'CLIENT_SECRET', 'CLIENT_REDIRECT_URI'].reduce((acc, v) => {
@@ -59,7 +60,7 @@ const oidcConfig = {
 
 };
 
-const oidc = new Provider(`http://${host}:${ext_port}`, oidcConfig);
+const oidc = new Provider(`http://${host}${ext_port ? ':' : ''}${ext_port}`, oidcConfig);
 
 const clients= [{
     client_id: config.clientId,

--- a/dev-server/oidc/server.js
+++ b/dev-server/oidc/server.js
@@ -3,6 +3,7 @@ const camelCase = require('camelcase');
 const Provider = require('oidc-provider');
 
 const port = process.env.PORT || 3000;
+const ext_port = process.env.EXTERNAL_PORT || process.env.PORT;
 const host = process.env.HOST || "oidc" ;
 
 const config = ['CLIENT_ID', 'CLIENT_SECRET', 'CLIENT_REDIRECT_URI'].reduce((acc, v) => {
@@ -58,7 +59,7 @@ const oidcConfig = {
 
 };
 
-const oidc = new Provider(`http://${host}:${port}`, oidcConfig);
+const oidc = new Provider(`http://${host}:${ext_port}`, oidcConfig);
 
 const clients= [{
     client_id: config.clientId,

--- a/elixir_test.go
+++ b/elixir_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+// These are not complete tests of all functions in elixir. New tests should
+// be added as the code is updated.
+
+func TestRemoveHost(t *testing.T) {
+	if removeHost("test1") != "test1" {
+		t.Error("removeHost should return the input string when given 'test1'")
+	}
+	if removeHost("test2@test.com") != "test2" {
+		t.Error("removeHost should return 'test2' when given 'test2@test.com'")
+	}
+	if removeHost("test3@test@test.com") != "test3" {
+		t.Error("removeHost should return 'test3' when given " +
+			"'test3@test@test.com'")
+	}
+}


### PR DESCRIPTION
This PR does two things:

- Mainly, it parses the host part from elixir usernames, so that they no longer contain an @ symbol,
- Secondly, it adds `EXTERNAL_PORT` support to the mock oidc, so that it can be run through a proxy more easily.

Closes #89 