### PR TITLE
[Feature] Auth logs in json format

### DIFF
--- a/config.go
+++ b/config.go
@@ -92,6 +92,13 @@ func (c *Config) readConfig() {
 
 	c.S3Inbox = viper.GetString("s3Inbox")
 
+	if viper.IsSet("log.format") {
+		if viper.GetString("log.format") == "json" {
+			log.SetFormatter(&log.JSONFormatter{})
+			log.Info("The logs format is set to JSON")
+		}
+	}
+
 	if viper.IsSet("log.level") {
 		stringLevel := viper.GetString("log.level")
 		intLevel, err := log.ParseLevel(stringLevel)

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 ---
 log:
   level: "info"
+  format: "json"
 elixir:
   id: "XC56EL11xx"
   issuer: "http://oidc:9090"

--- a/main.go
+++ b/main.go
@@ -245,9 +245,6 @@ func (auth AuthHandler) getElixirConf(ctx iris.Context) {
 
 func main() {
 
-	// Set JSON log formatter
-	log.SetFormatter(&log.JSONFormatter{})
-
 	// Initialise config
 	config := NewConfig()
 


### PR DESCRIPTION
It is the same like in [pipeline repo](https://github.com/neicnordic/sda-pipeline), logs format moved in the config and one can choose between json and text format

Closes #122