### PR TITLE
update linter #none

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
-          args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck
+          version: v1.45
+          args: -E gosec,goconst,nestif,bodyclose,rowserrcheck


### PR DESCRIPTION
This should fix the linter error in #131 and #132. The `interfacer` linter is deprecated so I removed it.