### PR TITLE
Update cors config in docker compose

### DIFF
--- a/dev-server/docker-compose.yml
+++ b/dev-server/docker-compose.yml
@@ -62,8 +62,8 @@ services:
       - CEGA_JWTPRIVATEKEY=keys/sign-jwt.key
       - CEGA_JWTSIGNATUREALG=ES256
       - CEGA_SECRET=dummy
-      - CORS_ORIGINS=http://localhost:8000
-      - CORS_METHODS=GET,OPTIONS
+      - CORS_ORIGINS=http://localhost:8080
+      - CORS_METHODS=GET,POST, OPTIONS
       - CORS_CREDENTIALS=TRUE
       - LOG_LEVEL=info
       - S3INBOX=s3.example.com


### PR DESCRIPTION
The EGA authentication was not functional due to CORS configuration in the docker compose. The update in the CORS methods and origins solves this issue