### PR TITLE
Replace the '@' character in s3 config file

### DIFF
--- a/elixir.go
+++ b/elixir.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc"
@@ -43,20 +42,6 @@ func getOidcClient(conf ElixirConfig) (oauth2.Config, *oidc.Provider) {
 	}
 
 	return oauth2Config, provider
-}
-
-// If the given string is formatted like <user>@<host>, only the <user> part is
-// returned, otherwise the original string is returned.
-// Note that this function will split on the first '@' symbol, and not the last
-// like an e-mail parser would. This is to ensure that there are no @ signs in
-// the returned username.
-func removeHost(raw string) string {
-	index := strings.Index(raw, "@")
-	if index > -1 {
-		return raw[:index]
-	}
-
-	return raw
 }
 
 // Authenticate with an Oidc client.against Elixir AAI
@@ -112,7 +97,7 @@ func authenticateWithOidc(oauth2Config oauth2.Config, provider *oidc.Provider, c
 	}
 
 	idStruct = ElixirIdentity{
-		User:     removeHost(userInfo.Subject),
+		User:     userInfo.Subject,
 		Token:    rawIDToken,
 		Passport: claims.PassportClaim,
 		Profile:  claims.ProfileClaim,

--- a/elixir_test.go
+++ b/elixir_test.go
@@ -131,12 +131,6 @@ func (suite *ElixirTests) TestGetOidcClient() {
 	assert.Equal(suite.T(), []string{"openid", "ga4gh_passport_v1 profile email"}, oauth2Config.Scopes, "oauth2Config has the wrong scopes")
 }
 
-func (suite *ElixirTests) TestRemoveHost() {
-	assert.Equal(suite.T(), "test1", removeHost("test1"), "removeHost should return the input string when given 'test1'")
-	assert.Equal(suite.T(), "test2", removeHost("test2@test.com"), "removeHost should return 'test2' when given 'test2@test.com'")
-	assert.Equal(suite.T(), "test3", removeHost("test3@test@test.com"), "removeHost should return 'test3' when given 'test3@test@test.com'")
-}
-
 func (suite *ElixirTests) TestAuthenticateWithOidc() {
 
 	// Create a code to authenticate

--- a/s3conf.go
+++ b/s3conf.go
@@ -1,7 +1,12 @@
 package main
 
+import "strings"
+
 // Retrieve a config map containing s3cmd configuration values
 func getS3ConfigMap(token, inboxHost, user string) map[string]string {
+	if strings.Contains(user, "@") {
+		user = strings.ReplaceAll(user, "@", "_")
+	}
 	s3conf := map[string]string{"access_key": user,
 		"secret_key":              user,
 		"access_token":            token,


### PR DESCRIPTION
The new CEGA login is working with accounts containing the email as username, leading to access and secret keys containing the `@` character. This pull request replaces the `@` with `_` so that we maintain the uniqueness of the username, while allowing for S3 to accept the username and create a folder with that name.