### PR TITLE
Check jwt key on startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -161,6 +163,10 @@ func (c *Config) readConfig() error {
 		if viper.GetString(s) == "" {
 			return fmt.Errorf("%s not set", s)
 		}
+	}
+
+	if _, err := os.Stat(c.JwtPrivateKey); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("Error when reading from private key file, reason: '%s'", err)
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -166,7 +166,7 @@ func (c *Config) readConfig() error {
 	}
 
 	if _, err := os.Stat(c.JwtPrivateKey); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("Error when reading from private key file, reason: '%s'", err)
+		return fmt.Errorf("Missing private key file, reason: '%s'", err)
 	}
 
 	return nil

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ log:
   format: "json"
 elixir:
   id: "XC56EL11xx"
-  issuer: "http://oidc:9090"
+  provider: "http://oidc:9090"
   redirectUri: "http://oidc:31111/elixir/login"
   revocationUrl: "http://oidc:9090"
   secret: "wHPVQaYXmdDHg"


### PR DESCRIPTION
This PR adds checking that the private jwt key which is provided in the configuration corresponds to an existing file. The check is performed as early as possible at the `config` module and the app will therefore exit with error if it cannot find the key file
upon startup.

Closes #125