### PR TITLE
Enhancement/improve security policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 *.so
 *.dylib
 
+# Service binaries
+auth
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/frontend/static/custom.css
+++ b/frontend/static/custom.css
@@ -1,0 +1,15 @@
+#loginbox {
+    max-width: 800px;
+}
+
+#egalogin {
+    max-width: 400px;
+}
+
+#loginbox1 {
+    max-width: 600px;
+}
+
+#logintext {
+    user-select: "all";
+}

--- a/frontend/static/login.js
+++ b/frontend/static/login.js
@@ -1,0 +1,14 @@
+$.get('/login-options', (options) => {
+    options.forEach(option => {
+        $("#login-options").append(
+            `<div class="col-sm py-3">
+      <p class="lead">
+        For logging in with ${option.Name} please click here:
+      </p>
+      <a class="btn btn-primary btn-lg btn-block" href="${option.URL}">
+        Log in with ${option.Name}
+      </a>
+    </div>
+    `);
+    });
+});

--- a/frontend/templates/ega.html
+++ b/frontend/templates/ega.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>SDA authentication service</title>
 <link rel="stylesheet" href="../public/bootstrap.min.css">
+<link rel="stylesheet" href="../public/custom.css">
 </head>
 
 <body>
@@ -25,7 +26,7 @@
         </div>
     </nav>
     <div class="jumbotron" role="region">
-      <div class="container" style="max-width: 600px">
+      <div class="container" id="loginbox1">
             <p class="lead text-center">
               Welcome, {{.User}}!
             </p>
@@ -33,13 +34,13 @@
             <p class="text-center">
               Your access token is:
             </p>
-            <pre class="border border-secondary rounded py-2 px-3 my-4" style="user-select: all;">{{.Token}}</pre>
+            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.Token}}</pre>
             {{end}}
             {{if .ExpDate}}
             <p class="text-center">
               Your access token expires (UTC):
             </p>
-            <pre class="text-center" style="user-select: all;">{{.ExpDate}}</pre>
+            <pre class="text-center" id="logintext">{{.ExpDate}}</pre>
             {{end}}
             <a href="/ega/s3conf" class="btn btn-primary btn-block">Download inbox s3cmd credentials</a>
             <a href="/" class="btn btn-primary btn-block">Continue</a>

--- a/frontend/templates/elixir.html
+++ b/frontend/templates/elixir.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>SDA authentication service</title>
 <link rel="stylesheet" href="../public/bootstrap.min.css">
+<link rel="stylesheet" href="../public/custom.css">
 </head>
 
 <body>
@@ -25,7 +26,7 @@
         </div>
     </nav>
     <div class="jumbotron" role="region">
-      <div class="container" style="max-width: 600px">
+      <div class="container" id="loginbox1">
             <p class="lead text-center">
               Welcome, {{.User}}!
             </p>
@@ -34,20 +35,20 @@
               Your visas are the following:
             </p>
             {{ range .Passport }}
-            <pre class="border border-secondary rounded py-2 px-3 my-4" style="user-select: all;">{{.}}</pre>
+            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.}}</pre>
             {{ end }}
             {{ end }}
             {{if .Token}}
             <p class="text-center">
               Your access token is:
             </p>
-            <pre class="border border-secondary rounded py-2 px-3 my-4" style="user-select: all;">{{.Token}}</pre>
+            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.Token}}</pre>
             {{end}}
             {{if .ExpDate}}
             <p class="text-center">
               Your access token expires (UTC):
             </p>
-            <pre class="text-center" style="user-select: all;">{{.ExpDate}}</pre>
+            <pre class="text-center" id="logintext">{{.ExpDate}}</pre>
             {{end}}
             <a href="/elixir/s3conf" class="btn btn-primary btn-block">Download inbox s3cmd credentials</a>
             <a href="/" class="btn btn-primary btn-block">Continue</a>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>SDA authentication service</title>
 <link rel="stylesheet" href="public/bootstrap.min.css">
+<link rel="stylesheet" href="public/custom.css">
 </head>
 
 <body>
@@ -25,7 +26,7 @@
         </div>
     </nav>
     <div class="jumbotron text-center" role="region">
-  <div class="container" style="max-width: 800px;">
+  <div class="container" id="loginbox">
     <div class="row justify-content-md-center">
       <div class="col-sm">
         <h3>SDA authentication service</h3>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -36,22 +36,6 @@
 </div>
     <script src="public/jquery-3.5.1.min.js"></script>
     <script src="public/bootstrap.min.js"></script>
-    <script>
-      $.get('/login-options', (options) => {
-        options.forEach(option => {
-        $("#login-options").append(
-          `<div class="col-sm py-3">
-            <p class="lead">
-              For logging in with ${option.Name} please click here:
-            </p>
-            <a class="btn btn-primary btn-lg btn-block" href="${option.URL}">
-              Log in with ${option.Name}
-            </a>
-          </div>
-          `);
-        });
-      });
-    </script>
+    <script src="public/login.js"></script>
 </body>
 </html>
-

--- a/frontend/templates/loginform.html
+++ b/frontend/templates/loginform.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>SDA authentication service</title>
 <link rel="stylesheet" href="../public/bootstrap.min.css">
+<link rel="stylesheet" href="../public/custom.css">
 </head>
 
 <body>
@@ -27,7 +28,7 @@
 
 
 <div class="jumbotron" role="region">
-    <form class="container" style="max-width: 400px;" action="/ega" method="post">
+  <form class="container" id="egalogin" action="/ega" method="post">
         <div class="row justify-content-center pb-4">
           <h3 class="col">EGA authentication</h1>
         </div>

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func (auth AuthHandler) getInboxConfig(ctx iris.Context, authType string) {
 // getMain returns the index.html page
 func (auth AuthHandler) getMain(ctx iris.Context) {
 	ctx.ResponseWriter().Header().Set("Content-Security-Policy", "default-src 'self';"+
-		"script-src-elem 'self' 'sha256-/jbtqE43/+Srt0XgGujfzyEondwNbvz3rt+ny8ocPZE=';"+
+		"script-src-elem 'self';"+
 		"img-src 'self' data:;"+
 		"frame-ancestors 'none';"+
 		"form-action 'none'")

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func (auth AuthHandler) getMain(ctx iris.Context) {
 
 	ctx.ResponseWriter().Header().Set("Referrer-Policy", "no-referrer")
 	ctx.ResponseWriter().Header().Set("X-Content-Type-Options", "nosniff")
-	ctx.ResponseWriter().Header().Set("X-Frame-Options", "DENY") // legacy option, obsolete by CSP frame-abcestors in new browsers
+	ctx.ResponseWriter().Header().Set("X-Frame-Options", "DENY") // legacy option, obsolete by CSP frame-ancestors in new browsers
 
 	err := ctx.View("index.html")
 	if err != nil {
@@ -194,7 +194,7 @@ func (auth AuthHandler) getEGALogin(ctx iris.Context) {
 
 	ctx.ResponseWriter().Header().Set("Referrer-Policy", "no-referrer")
 	ctx.ResponseWriter().Header().Set("X-Content-Type-Options", "nosniff")
-	ctx.ResponseWriter().Header().Set("X-Frame-Options", "DENY") // legacy option, obsolete by CSP frame-abcestors in new browsers
+	ctx.ResponseWriter().Header().Set("X-Frame-Options", "DENY") // legacy option, obsolete by CSP frame-ancestors in new browsers
 
 	s := sessions.Get(ctx)
 	message := s.GetFlashString("message")

--- a/main.go
+++ b/main.go
@@ -75,6 +75,8 @@ func (auth AuthHandler) getMain(ctx iris.Context) {
 
 	ctx.ResponseWriter().Header().Set("Referrer-Policy", "no-referrer")
 	ctx.ResponseWriter().Header().Set("X-Content-Type-Options", "nosniff")
+	ctx.ResponseWriter().Header().Set("X-Frame-Options", "DENY") // legacy option, obsolete by CSP frame-abcestors in new browsers
+
 	err := ctx.View("index.html")
 	if err != nil {
 		log.Error("Failed to view index page: ", err)
@@ -192,6 +194,7 @@ func (auth AuthHandler) getEGALogin(ctx iris.Context) {
 
 	ctx.ResponseWriter().Header().Set("Referrer-Policy", "no-referrer")
 	ctx.ResponseWriter().Header().Set("X-Content-Type-Options", "nosniff")
+	ctx.ResponseWriter().Header().Set("X-Frame-Options", "DENY") // legacy option, obsolete by CSP frame-abcestors in new browsers
 
 	s := sessions.Get(ctx)
 	message := s.GetFlashString("message")

--- a/main.go
+++ b/main.go
@@ -67,6 +67,12 @@ func (auth AuthHandler) getInboxConfig(ctx iris.Context, authType string) {
 
 // getMain returns the index.html page
 func (auth AuthHandler) getMain(ctx iris.Context) {
+	ctx.ResponseWriter().Header().Set("Content-Security-Policy", "default-src 'self';"+
+		"script-src-elem 'self' 'sha256-/jbtqE43/+Srt0XgGujfzyEondwNbvz3rt+ny8ocPZE=';"+
+		"img-src 'self' data:;"+
+		"frame-ancestors 'none';"+
+		"form-action 'none'")
+
 	ctx.ResponseWriter().Header().Set("Referrer-Policy", "no-referrer")
 	ctx.ResponseWriter().Header().Set("X-Content-Type-Options", "nosniff")
 	err := ctx.View("index.html")
@@ -179,6 +185,11 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 
 // getEGALogin returns the EGA login form
 func (auth AuthHandler) getEGALogin(ctx iris.Context) {
+	ctx.ResponseWriter().Header().Set("Content-Security-Policy", "default-src 'self';"+
+		"img-src 'self' data:;"+
+		"frame-ancestors 'none';"+
+		"form-action 'self'")
+
 	ctx.ResponseWriter().Header().Set("Referrer-Policy", "no-referrer")
 	ctx.ResponseWriter().Header().Set("X-Content-Type-Options", "nosniff")
 


### PR DESCRIPTION
This PR adds some header directives to `sda-auth`  that provide an extra security layer to the service. It implements a quite strict Content Security Policy to some of auth's endpoint handling and it also adds other relevant security related directives to other endpoints where necessary. The changes are tested and deployed on the `fega-test` cluster and can be checked online [here](https://webbkoll.dataskydd.net/en?url=http%3A%2F%2Flogin.test.fega.nbis.se%2F).

Closes #186
