### PR TITLE
Feature/opt to serve original jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Parameter | Description | Defined value
 `JWTISSUER` | Issuer of JWT tokens | `http://auth:8080`
 `JWTPRIVATEKEY` | Path to private key for signing the JWT token | `keys/sign-jwt.key`
 `JWTSIGNATUREALG` | Algorithm used to sign the JWT token. ES256 (ECDSA) or RS256 (RSA) are supported | `RS256`
+`RESIGNJWT` | Set to `false` to serve the raw OIDC JWT, i.e. without re-signing it | `""`
 
 ## Running the development setup
 

--- a/config.go
+++ b/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	JwtSignatureAlg string
 	Server          ServerConfig
 	S3Inbox         string
+	ResignJwt       bool
 }
 
 // NewConfig initializes and parses the config file and/or environment using
@@ -89,6 +90,9 @@ func (c *Config) readConfig() error {
 	c.JwtPrivateKey = viper.GetString("JwtPrivateKey")
 	c.JwtSignatureAlg = viper.GetString("JwtSignatureAlg")
 	c.JwtIssuer = viper.GetString("jwtIssuer")
+
+	viper.SetDefault("ResignJwt", true)
+	c.ResignJwt = viper.GetBool("resignJwt")
 
 	// Setup elixir
 	elixir := ElixirConfig{}

--- a/config.yaml
+++ b/config.yaml
@@ -21,3 +21,4 @@ s3Inbox: "s3.example.com"
 jwtIssuer: "http://auth:8080"
 jwtPrivateKey: "keys/sign-jwt.key"
 jwtSignatureAlg: "ES256"
+resignJwt: true

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -28,6 +29,7 @@ type ConfigTests struct {
 	JwtPrivateKey     string
 	JwtPrivateKeyFile *os.File
 	JwtSignatureAlg   string
+	ResignJwt         bool
 }
 
 func TestConfigTestSuite(t *testing.T) {
@@ -82,6 +84,7 @@ func (suite *ConfigTests) SetupTest() {
 	suite.JwtIssuer = "JwtIssuer"
 	suite.JwtPrivateKey = suite.JwtPrivateKeyFile.Name()
 	suite.JwtSignatureAlg = "RS256"
+	suite.ResignJwt = true
 
 	// Write config to temp config file
 	configYaml, err := yaml.Marshal(Config{
@@ -92,6 +95,7 @@ func (suite *ConfigTests) SetupTest() {
 		JwtIssuer:       suite.JwtIssuer,
 		JwtPrivateKey:   suite.JwtPrivateKey,
 		JwtSignatureAlg: suite.JwtSignatureAlg,
+		ResignJwt:       suite.ResignJwt,
 	})
 	if err != nil {
 		log.Errorf("Error marshalling config yaml: %v", err)
@@ -141,6 +145,7 @@ func (suite *ConfigTests) TestConfig() {
 	assert.Equal(suite.T(), suite.JwtIssuer, config.JwtIssuer, "JwtIssuer misread from config file")
 	assert.Equal(suite.T(), suite.JwtPrivateKey, config.JwtPrivateKey, "JwtPrivateKey misread from config file")
 	assert.Equal(suite.T(), suite.JwtSignatureAlg, config.JwtSignatureAlg, "JwtSignatureAlg misread from config file")
+	assert.Equal(suite.T(), suite.ResignJwt, config.ResignJwt, "ResignJwt misread from config file")
 
 	// sanitycheck without config file or ENVs
 	// this should fail
@@ -167,6 +172,7 @@ func (suite *ConfigTests) TestConfig() {
 	os.Setenv("JWTISSUER", fmt.Sprintf("env_%v", suite.JwtIssuer))
 	os.Setenv("JWTPRIVATEKEY", fmt.Sprintf("%v_env", suite.JwtPrivateKey))
 	os.Setenv("JWTSIGNATUREALG", fmt.Sprintf("env_%v", suite.JwtSignatureAlg))
+	os.Setenv("RESIGNJWT", fmt.Sprintf("%t", suite.ResignJwt))
 
 	// re-read the config
 	config, err = NewConfig()
@@ -189,6 +195,7 @@ func (suite *ConfigTests) TestConfig() {
 	assert.Equal(suite.T(), fmt.Sprintf("env_%v", suite.JwtIssuer), config.JwtIssuer, "JwtIssuer misread from environment variable")
 	assert.Equal(suite.T(), fmt.Sprintf("%v_env", suite.JwtPrivateKey), config.JwtPrivateKey, "JwtPrivateKey misread from environment variable")
 	assert.Equal(suite.T(), fmt.Sprintf("env_%v", suite.JwtSignatureAlg), config.JwtSignatureAlg, "JwtSignatureAlg misread from environment variable")
+	assert.Equal(suite.T(), fmt.Sprintf("%t", suite.ResignJwt), strconv.FormatBool(config.ResignJwt), "ResignJwt misread from environment variable")
 
 	// Check missing private key
 	os.Setenv("JWTPRIVATEKEY", "nonexistent-key-file")

--- a/elixir.go
+++ b/elixir.go
@@ -150,11 +150,15 @@ func validateToken(rawJwt, jwksURL string) (*jwt.Token, string, error) {
 		return nil, "", fmt.Errorf(err.Error())
 	}
 
-	d, ok := token.Claims.(jwt.MapClaims)["exp"].(float64)
-	if !ok {
-		log.Error("failed to read expiration date from token")
+	var expireDate time.Time
+	switch d := token.Claims.(jwt.MapClaims)["exp"].(type) {
+	case float64:
+		expireDate = time.Unix(int64(d), 0)
+	case int64:
+		expireDate = time.Unix(d, 0)
+	default:
+		return nil, "", fmt.Errorf("failed to read expiration date from token")
 	}
-	expireDate := time.Unix(int64(d), 0)
 
 	return token, expireDate.Format("2006-01-02 15:04:05"), err
 }

--- a/elixir.go
+++ b/elixir.go
@@ -144,6 +144,12 @@ func validateToken(rawJwt, jwksURL string) (*jwt.Token, string, error) {
 		return nil, "", fmt.Errorf("signature not valid: %s", err.Error())
 	}
 
+	// Verify token dates. Ignores clock skew, but that should be
+	// irrelevant here since tokens are relatively long-lived
+	if err := token.Claims.(jwt.MapClaims).Valid(); err != nil {
+		return nil, "", fmt.Errorf(err.Error())
+	}
+
 	d, ok := token.Claims.(jwt.MapClaims)["exp"].(float64)
 	if !ok {
 		log.Error("failed to read expiration date from token")

--- a/elixir_test.go
+++ b/elixir_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/oauth2-proxy/mockoidc"
@@ -157,7 +158,8 @@ func (suite *ElixirTests) TestValidateJwt() {
 	// Create HS256 test token
 	mySigningKey := []byte("AllYourBase")
 	claims := &jwt.RegisteredClaims{
-		Issuer: "test",
+		Issuer:    "test",
+		ExpiresAt: jwt.NewNumericDate(time.Now().UTC().Add(time.Hour)),
 	}
 	tokenHS256 := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	testTokenHS256, err := tokenHS256.SignedString(mySigningKey)
@@ -191,7 +193,7 @@ func (suite *ElixirTests) TestValidateJwt() {
 	token, expDate, err := validateToken(elixirJWT, suite.mockServer.JWKSEndpoint())
 	if assert.Nil(suite.T(), err) {
 		assert.True(suite.T(), token.Valid, "Validation failed but without returning errors")
-		assert.NotEmpty(suite.T(), expDate, "Validation failed but without returning errors")
+		assert.Equal(suite.T(), expDate, elixirIdentity.ExpDate, "Returned wrong exp date but without returning errors")
 	}
 
 	// wrong jwk url

--- a/elixir_test.go
+++ b/elixir_test.go
@@ -229,4 +229,14 @@ func (suite *ElixirTests) TestValidateJwt() {
 	// expired token
 	_, _, err = validateToken(testExpiredTokenRSA, suite.mockServer.JWKSEndpoint())
 	assert.Equal(suite.T(), "Token is expired", err.Error())
+
+	// check that we handle the case where token has no expiration date
+	claims.ExpiresAt = nil
+	expiredTokenRSA = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	testExpiredTokenRSA, err = expiredTokenRSA.SignedString(rsaKey)
+	if err != nil {
+		log.Error(err)
+	}
+	_, _, err = validateToken(testExpiredTokenRSA, suite.mockServer.JWKSEndpoint())
+	assert.ErrorContains(suite.T(), err, "signature not valid")
 }

--- a/elixir_test.go
+++ b/elixir_test.go
@@ -188,29 +188,30 @@ func (suite *ElixirTests) TestValidateJwt() {
 	}
 
 	// sanity check
-	token, err := validateToken(elixirJWT, suite.mockServer.JWKSEndpoint())
+	token, expDate, err := validateToken(elixirJWT, suite.mockServer.JWKSEndpoint())
 	if assert.Nil(suite.T(), err) {
 		assert.True(suite.T(), token.Valid, "Validation failed but without returning errors")
+		assert.NotEmpty(suite.T(), expDate, "Validation failed but without returning errors")
 	}
 
 	// wrong jwk url
-	_, err = validateToken(elixirJWT, "http://some/jwk/endpoint")
+	_, _, err = validateToken(elixirJWT, "http://some/jwk/endpoint")
 	assert.ErrorContains(suite.T(), err, "failed to fetch remote JWK")
 
 	// wrong signing method
-	_, err = validateToken(testTokenHS256, suite.mockServer.JWKSEndpoint())
+	_, _, err = validateToken(testTokenHS256, suite.mockServer.JWKSEndpoint())
 	if assert.Error(suite.T(), err) {
 		assert.Equal(suite.T(), "unexpected signing method", err.Error())
 	}
 
 	// wrong private key, RSA
-	_, err = validateToken(testTokenRSA, suite.mockServer.JWKSEndpoint())
+	_, _, err = validateToken(testTokenRSA, suite.mockServer.JWKSEndpoint())
 	if assert.Error(suite.T(), err) {
 		assert.Equal(suite.T(), "signature not valid: crypto/rsa: verification error", err.Error())
 	}
 
 	// wrong private key, ECDSA
-	_, err = validateToken(testTokenEC, suite.mockServer.JWKSEndpoint())
+	_, _, err = validateToken(testTokenEC, suite.mockServer.JWKSEndpoint())
 	if assert.Error(suite.T(), err) {
 		assert.Equal(suite.T(), "signature not valid: key is of invalid type", err.Error())
 	}


### PR DESCRIPTION
This PR makes resigning of JWTs a configurable option. In this way,

- if `sda-auth` is  deployed with `resignJwt`=`false`, then the original (raw) token will be served instead i.e. the raw LS AAI token.

- if `resignJwt`=`true`, it will continue working as before i.e. serve re-signed tokens with our own key.

-  `resignJwt` defaults to `true` so that the service works as before if not set. 

Note that the served `s3cfg` file will hold the same token that is served through the webui.

The go testsuite is updated accordingly.

Closes #201.