### PR TITLE
Small batch of fixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -163,14 +163,23 @@ func (c *Config) readConfig() error {
 		log.Printf("Setting log level to '%s'", stringLevel)
 	}
 
-	for _, s := range []string{"jwtIssuer", "JwtPrivateKey", "JwtSignatureAlg", "s3Inbox"} {
+	if viper.GetString("s3Inbox") == "" {
+		return fmt.Errorf("%s not set", "s3Inbox")
+	}
+
+	// no need to check the variables for JWT generation if we won't use it
+	if (cega.ID == "" && cega.Secret == "") && !c.ResignJwt {
+		return nil
+	}
+
+	for _, s := range []string{"jwtIssuer", "JwtPrivateKey", "JwtSignatureAlg"} {
 		if viper.GetString(s) == "" {
 			return fmt.Errorf("%s not set", s)
 		}
 	}
 
 	if _, err := os.Stat(c.JwtPrivateKey); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("Missing private key file, reason: '%s'", err)
+		return fmt.Errorf("missing private key file, reason: '%s'", err.Error())
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -202,5 +202,14 @@ func (suite *ConfigTests) TestConfig() {
 
 	// re-read the config
 	_, err = NewConfig()
-	assert.ErrorContains(suite.T(), err, "Missing private key file")
+	assert.ErrorContains(suite.T(), err, "missing private key file")
+
+	// Repeat check with CEGA login and JWT resigning disabled
+	os.Setenv("CEGA_ID", "")
+	os.Setenv("CEGA_SECRET", "")
+	os.Setenv("RESIGNJWT", fmt.Sprintf("%t", false))
+
+	// re-read the config
+	_, err = NewConfig()
+	assert.NoError(suite.T(), err)
 }

--- a/dev-server/oidc/server.js
+++ b/dev-server/oidc/server.js
@@ -22,7 +22,7 @@ const oidcConfig = {
     revocation: true,
     sessionManagement: false
   },
-  format: {
+  formats: {
     default: 'jwt',
     AccessToken: 'jwt',
     RefreshToken: 'jwt'

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func (auth AuthHandler) getInboxConfig(ctx iris.Context, authType string) {
 	}
 	s3cfmap := s3conf.(map[string]string)
 	ctx.ResponseWriter().Header().Set("Content-Disposition", "attachment; filename=s3cmd.conf")
-	var s3c string
+	var s3c string = "[default]\n"
 
 	for k, v := range s3cfmap {
 		entry := fmt.Sprintf("%s = %s\n", k, v)
@@ -239,7 +239,7 @@ func (auth AuthHandler) elixirLogin(ctx iris.Context) *OIDCData {
 	code := ctx.Request().URL.Query().Get("code")
 	idStruct, err := authenticateWithOidc(auth.OAuth2Config, auth.OIDCProvider, code, auth.Config.Elixir.jwkURL)
 	if err != nil {
-		log.WithFields(log.Fields{"authType": "elixir"}).Errorf("Auhentication failed: %s", err)
+		log.WithFields(log.Fields{"authType": "elixir"}).Errorf("Authentication failed: %s", err)
 		_, err := ctx.Writef("Authentication failed. You may need to clear your session cookies and try again.")
 		if err != nil {
 			log.Error("Failed to write response: ", err)


### PR DESCRIPTION
This PR contains a few small stuff that came up while working with  `sda-auth` for the GDI starter-kit which seem worthwhile to fix:

- It is possible to deploy `auth` without cega-login and without token-resigning, as was done e.g. for the GDI starter-kit. In that case the service should be able to work without configuration variables that are specific to the  jwt signing functionality of `auth` (e.g. private key for signing etc) . This is addressed here.

- The recent change in `auth` to serve access tokens, broke the compatibility between the service and the mockoidc included in the repo (which I did not realize because I had the `ls-aai-mock` service hooked with `auth` at the time).
This was due to the fact that the `formats` method in `dev-server/oidc/server.js` was misspelled all along and therefore the oidc-provider was serving opaque access tokens per the default which were unreadable by `auth`. 
(sadly, finding that missing `s` with a package that has undergone three massive breaking changes since the v5.5.2 that we use took some time, but at least it works now ;-)

- `sda-auth` is now setup to serve `s3cmd` `config` files which can be used with `s3cmd` out-of-the-box. Note that the `sda-cli` is able parse `s3cmd.conf` files with a header section.

Closes #227